### PR TITLE
Zombie armor fix #19

### DIFF
--- a/crafting-dead-core/src/main/java/com/craftingdead/core/capability/living/DefaultLiving.java
+++ b/crafting-dead-core/src/main/java/com/craftingdead/core/capability/living/DefaultLiving.java
@@ -42,6 +42,7 @@ import net.minecraft.entity.Pose;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.nbt.ListNBT;
 import net.minecraft.potion.EffectInstance;
 import net.minecraft.potion.Effects;
 import net.minecraft.tags.FluidTags;
@@ -380,6 +381,15 @@ public class DefaultLiving<E extends LivingEntity, L extends ILivingHandler>
     for (Map.Entry<ResourceLocation, L> entry : this.extensions.entrySet()) {
       nbt.put(entry.getKey().toString(), entry.getValue().serializeNBT());
     }
+    IItemHandlerModifiable itemHandler = this.getItemHandler();
+    ListNBT listNBT = new ListNBT();
+    for (int i = 0; i < itemHandler.getSlots(); i++) {
+      CompoundNBT stackNbt = new CompoundNBT();
+      ItemStack stackInSlot = itemHandler.getStackInSlot(i);
+      stackInSlot.write(stackNbt);
+      listNBT.add(stackNbt);
+    }
+    nbt.put("cd_inventory", listNBT);
     return nbt;
   }
 
@@ -389,6 +399,14 @@ public class DefaultLiving<E extends LivingEntity, L extends ILivingHandler>
       CompoundNBT extensionNbt = nbt.getCompound(entry.getKey().toString());
       if (!extensionNbt.isEmpty()) {
         entry.getValue().deserializeNBT(extensionNbt);
+      }
+    }
+    if (nbt.contains("cd_inventory")) {
+      ListNBT items = nbt.getList("cd_inventory", 10);
+      IItemHandlerModifiable itemHandler = this.getItemHandler();
+      for (int i = 0; i < items.size(); i++) {
+        ItemStack itemStack = ItemStack.read(items.getCompound(i));
+        itemHandler.setStackInSlot(i, itemStack);
       }
     }
   }

--- a/crafting-dead-core/src/main/java/com/craftingdead/core/network/NetworkChannel.java
+++ b/crafting-dead-core/src/main/java/com/craftingdead/core/network/NetworkChannel.java
@@ -18,20 +18,7 @@
 package com.craftingdead.core.network;
 
 import com.craftingdead.core.CraftingDead;
-import com.craftingdead.core.network.message.play.CancelActionMessage;
-import com.craftingdead.core.network.message.play.CrouchMessage;
-import com.craftingdead.core.network.message.play.HitMessage;
-import com.craftingdead.core.network.message.play.KillFeedMessage;
-import com.craftingdead.core.network.message.play.OpenModInventoryMessage;
-import com.craftingdead.core.network.message.play.OpenStorageMessage;
-import com.craftingdead.core.network.message.play.PerformActionMessage;
-import com.craftingdead.core.network.message.play.SetSlotMessage;
-import com.craftingdead.core.network.message.play.SyncGunMessage;
-import com.craftingdead.core.network.message.play.SyncPlayerMessage;
-import com.craftingdead.core.network.message.play.ToggleFireModeMessage;
-import com.craftingdead.core.network.message.play.ToggleRightMouseAbility;
-import com.craftingdead.core.network.message.play.TriggerPressedMessage;
-import com.craftingdead.core.network.message.play.ValidateLivingHitMessage;
+import com.craftingdead.core.network.message.play.*;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.network.NetworkDirection;
 import net.minecraftforge.fml.network.NetworkRegistry;
@@ -138,6 +125,13 @@ public enum NetworkChannel {
           .encoder(KillFeedMessage::encode)
           .decoder(KillFeedMessage::decode)
           .consumer(KillFeedMessage::handle)
+          .add();
+
+      simpleChannel
+          .messageBuilder(SyncLivingMessage.class, 0x0E, NetworkDirection.PLAY_TO_CLIENT)
+          .encoder(SyncLivingMessage::encode)
+          .decoder(SyncLivingMessage::decode)
+          .consumer(SyncLivingMessage::handle)
           .add();
     }
   };

--- a/crafting-dead-core/src/main/java/com/craftingdead/core/network/message/play/SyncLivingMessage.java
+++ b/crafting-dead-core/src/main/java/com/craftingdead/core/network/message/play/SyncLivingMessage.java
@@ -1,0 +1,60 @@
+package com.craftingdead.core.network.message.play;
+
+import com.craftingdead.core.capability.ModCapabilities;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.LogicalSidedProvider;
+import net.minecraftforge.fml.network.NetworkEvent;
+import net.minecraftforge.items.IItemHandlerModifiable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class SyncLivingMessage {
+  private int entityId;
+  private Map<Integer, ItemStack> slotMap;
+
+
+  public SyncLivingMessage(int entityId, Map<Integer, ItemStack> slotMap) {
+    this.entityId = entityId;
+    this.slotMap = slotMap;
+  }
+
+  public static void encode(SyncLivingMessage msg, PacketBuffer out) {
+    out.writeInt(msg.entityId);
+    out.writeInt(msg.slotMap.size());
+    for (Map.Entry<Integer, ItemStack> slotEntry : msg.slotMap.entrySet()) {
+      out.writeInt(slotEntry.getKey());
+      out.writeItemStack(slotEntry.getValue());
+    }
+  }
+
+  public static SyncLivingMessage decode(PacketBuffer in) {
+    int entityId = in.readInt();
+    int size = in.readInt();
+    Map<Integer, ItemStack> stackMap = size > 0 ? new HashMap<>(size) : Collections.emptyMap();
+    for (int i = 0; i < size; i++) {
+      int slotId = in.readInt();
+      ItemStack stackInSlot = in.readItemStack();
+      stackMap.put(slotId, stackInSlot);
+    }
+    return new SyncLivingMessage(entityId, stackMap);
+  }
+
+  public static boolean handle(SyncLivingMessage msg, Supplier<NetworkEvent.Context> ctx) {
+    Optional<World> world = LogicalSidedProvider.CLIENTWORLD.get(ctx.get().getDirection().getReceptionSide());
+    world.map(world1 -> world1.getEntityByID(msg.entityId))
+        .map(entity -> entity.getCapability(ModCapabilities.LIVING).orElse(null))
+        .ifPresent(living -> {
+          IItemHandlerModifiable itemHandler = living.getItemHandler();
+          for (Map.Entry<Integer, ItemStack> slotEntry : msg.slotMap.entrySet()) {
+            itemHandler.setStackInSlot(slotEntry.getKey(), slotEntry.getValue());
+          }
+        });
+    return true;
+  }
+}


### PR DESCRIPTION
closes #19 

**Living Item Handler is now persisted:**
- Zombies won't lose clothing on game restart
- Players won't lose items in CD custom inventory on game restart

**ChangedDimension &  PlayerEvent.StartTracking server-client syncing:**
- Zombies'/other players' CD items (clothing, weapons, etc.)  won't visually disappear after player death
- Zombies'/other players' CD items won't visually disappear after changing dimensions
- Zombies'/other players' CD items won't visually disappear after leaving and joining the server
- Zombies'/other players' CD items won't visually disappear after going far away from them and then going back
- Own CD items won't visually disappear after changing dimensions

@Sm0keySa1m0n Please take a look at dispatching of SyncPlayerMessage in events, I'm not sure about that.
Also, if everything is fine, maybe is it worth including syncing of ItemHandler inside of SyncPlayerMessage, to not send 2 packets in some cases?



