### PR TITLE
Change kill sound to a smoother one

### DIFF
--- a/crafting-dead-core/src/main/java/com/craftingdead/core/network/message/play/HitMessage.java
+++ b/crafting-dead-core/src/main/java/com/craftingdead/core/network/message/play/HitMessage.java
@@ -22,6 +22,7 @@ import com.craftingdead.core.CraftingDead;
 import com.craftingdead.core.client.ClientDist;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.Vec3d;
 import net.minecraftforge.fml.network.NetworkEvent;
@@ -56,7 +57,9 @@ public class HitMessage {
                 .getIngameGui()::displayHitMarker);
         if (msg.dead && ClientDist.clientConfig.playKillSound.get()) {
           final Minecraft minecraft = Minecraft.getInstance();
-          minecraft.player.playSound(SoundEvents.BLOCK_ANVIL_PLACE, 5.0F, 1.0F);
+          // Plays a sound that follows the player
+          minecraft.world.playMovingSound(minecraft.player, minecraft.player,
+              SoundEvents.ITEM_TRIDENT_RETURN, SoundCategory.HOSTILE, 5.0F, 1.5F);
         }
       });
     }


### PR DESCRIPTION
This PR changes the kill sound (when using guns) from anvil land sound to the **trident return sound**.
The reason is that the anvil land sound is too loud and high-pitched, and can (_actually_) cause headache on some people.

The sound now follows the player, but on the other hand, it now needs to have a category to be played on.
Currently, it's using the `HOSTILE` category, unfortunately that's not the category that I wanted to use, but currently we don't have so much choices other than `MASTER.`

Here's a preview: https://streamable.com/o58edw
