### PR TITLE
Update build.gradle

### DIFF
--- a/crafting-dead-core/build.gradle
+++ b/crafting-dead-core/build.gradle
@@ -13,7 +13,7 @@ repositories {
 
 dependencies {
     implementation 'cpw.mods:bootstraplauncher:1.0.0' // Add the required dependency
-    implementation('io.sentry:sentry:5.6.0') {
+    api('io.sentry:sentry:5.6.0') {
         exclude group: 'com.google.code.gson', module: 'gson'
     }
 }


### PR DESCRIPTION
The survival build log still shows io.sentry.Scope missing, so I double-checked the fix: Sentry is now declared as an api dependency in build.gradle, which exposes it transitively to every module (including survival)